### PR TITLE
updated Kibana version to 5.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Use the time animation controls to easily explore data by time blocks. Click and
 ![preview-edit](/resources/time_animation.png)
 
 # Install
+## Kibana 5.0.1
+```bash
+./bin/kibana-plugin install https://github.com/nreese/kibana-time-plugin/releases/download/v5.0.1/kibana.zip
+```
+
 ## Kibana 5.0.0
 ```bash
 ./bin/kibana-plugin install https://github.com/nreese/kibana-time-plugin/releases/download/v5.0.0/kibana.zip

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
 	"name": "kibana-time-plugin",
-	"version": "5.0.0"
+	"version": "5.0.1"
 }


### PR DESCRIPTION
Hello,

I was not able to install this excellent plugin on Kibana 5.0.1. I had to modify package.json. Also the packaging structure seems to be different now:

```
Archive:  kibana.zip
    testing: kibana/                  OK
    testing: kibana/kibana-time-plugin/   OK
    testing: kibana/kibana-time-plugin/index.js   OK
[...]
```

I made a [release in my fork](https://github.com/fjgal/kibana-time-plugin/releases/download/v5.0.1/kibana.zip), you can test it from there if you want.

Thanks for making this great plugin!

/F
