### PR TITLE
6.6 breaking change 

### DIFF
--- a/public/time.js
+++ b/public/time.js
@@ -7,7 +7,6 @@ import 'plugins/kibana-time-plugin/bower_components/bootstrap-addons/dist/js/boo
 import 'plugins/kibana-time-plugin/time.less';
 import 'plugins/kibana-time-plugin/timeController';
 import { VisFactoryProvider } from 'ui/vis/vis_factory';
-import { CATEGORY } from 'ui/vis/vis_category';
 import { VisTypesRegistryProvider } from 'ui/registry/vis_types';
 import visTemplate from 'plugins/kibana-time-plugin/time.html';
 import optionsTemplate from 'plugins/kibana-time-plugin/timeOptions.html';
@@ -22,7 +21,6 @@ function TimeVisProvider(Private) {
     title: 'Time widget',
     icon: 'fa-clock-o',
     description: 'Add time inputs to your dashboards.',
-    category: CATEGORY.OTHER,
     visConfig: {
       template: visTemplate,
       defaults: {

--- a/public/timeController.js
+++ b/public/timeController.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import dateMath from '@kbn/datemath';
+import dateMath from '@elastic/datemath';
 import moment from 'moment';
 import 'ui/timepicker/time_units';
 import { SimpleEmitter } from 'ui/utils/simple_emitter';


### PR DESCRIPTION
#47 
By looking at the fatal errors when starting Kibana 6.6 with the plugin, found out the following breaking changes occurred:

- in timeController.js dateMath dependency have changed, now republish `@kbn/datemath` as `@elastic/datemath`
https://github.com/elastic/kibana/pull/26559

- With introduction of the new visualization type selection we removed the category key from visualizations. All you need to do is to remove the category key from your visualization registration.
https://www.elastic.co/blog/kibana-plugin-api-changes-in-6-6

The modification allowed Kibana to start with the module and the time-plugin seems functional.
